### PR TITLE
Use correct package version in artifact publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
           node-version: 14.x
       - run: yarn
       - run: yarn run publish
+      - name: get-package-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@main
       - uses: actions/upload-artifact@v3
         with:
           name: azure-cosmosdb-ads-extension
-          path: ./azure-cosmosdb-ads-extension-0.0.1.vsix
+          path: ./azure-cosmosdb-ads-extension-${{ steps.package-version.outputs.current-version }}.vsix


### PR DESCRIPTION
Version number is extracted from package.json to fix artifact publishing