### PR TITLE
Fix connection string when connecting with SqlLogin type

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
           "specialValueType": "serverName",
           "isIdentity": true,
           "name": "server",
-          "displayName": "Hostname:port or Cosmos DB account name",
+          "displayName": "Hostname:port or Cosmos DB host:port",
           "description": "Hostname(s) or Mongo Account",
           "groupName": "Source",
           "valueType": "string",

--- a/src/Providers/connectionString.ts
+++ b/src/Providers/connectionString.ts
@@ -65,8 +65,16 @@ export const buildMongoConnectionString = (options: {
     url.password = options["password"];
   }
 
-  url.pathname = options["pathname"];
-  url.search = options["search"];
+  url.pathname = options["pathname"] || "";
+  url.search = options["search"] || "";
 
+  // CosmosDB account need these parameters (hostname ends with cosmos.azure.com)
+  if (options.server.match(/\.cosmos\.azure\.com(:[0-9]*)*$/g)) {
+    url.searchParams.set("ssl", "true");
+    url.searchParams.set("replicaSet", "globaldb");
+    url.searchParams.set("retrywrites", "false");
+    url.searchParams.set("maxIdleTimeMS", url.searchParams.get("maxIdleTimeMS") || "120000");
+    url.searchParams.set("appName", `@${options.user}@`);
+  }
   return url.toString();
 };


### PR DESCRIPTION
The "Basic" authentication fails, because search parameters and pathnames are undefined.
Replace with empty strings instead.
Special case for cosmosdb accounts where we add required additional search parameters in the connection string url.