### PR TITLE
Remove ADS binaries from vsix package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,5 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+ads-binary/**
+

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,4 +9,3 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 ads-binary/**
-


### PR DESCRIPTION
ADS was inadvertently added to the vsix payload when the unit tests were fixed for CI (which downloads ads). We are ignoring it now.