### PR TITLE
Update aiKey

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "publisher": "Microsoft",
   "version": "0.1.4",
   "icon": "resources/catalog/CosmosDBExtension.png",
-  "aiKey": "AIF-37eefaf0-8022-4671-a3fb-64752724682e",
+  "aiKey": "29a207bb14f84905966a8f22524cb730-25407f35-11b6-4d4e-8114-ab9e843cb52f-7380",
   "preview": true,
   "repository": {
     "type": "git",
@@ -289,7 +289,7 @@
     "@azure/arm-cosmosdb": "13.0.0",
     "@azure/arm-monitor": "6.1.1",
     "@azure/arm-resourcegraph": "4.2.1",
-    "@microsoft/ads-extension-telemetry": "1.2.0",
+    "@microsoft/ads-extension-telemetry": "1.3.1",
     "@types/node-fetch": "2.6.2",
     "mkdirp": "1.0.4",
     "mongodb-connection-string-url": "2.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,10 +109,10 @@
     "@microsoft/applicationinsights-shims" "^2.0.1"
     "@microsoft/dynamicproto-js" "^1.1.6"
 
-"@microsoft/ads-extension-telemetry@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.2.0.tgz#f54e464ac887440727fe9862f8ff32be17aeab3a"
-  integrity sha512-dEp+RVJYo4uebMLvBJqJF8IABufJRp+PWHZx+3xe6SgAC37oYhcwR/glExhp3Nj3A2v3vjso6YQ/Wd5TG27FPQ==
+"@microsoft/ads-extension-telemetry@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.3.1.tgz#fa757ee88eac91b21c3a68562da6441c2ad15c39"
+  integrity sha512-8Zd7RwwN7ZufMoWFmc1bwzmQc1RV7/jf/Ua33YL1+P0ZwHoWFOhf/b0lwvAVzi9TB/7oD5zA5yv7A/i2sSTn6Q==
   dependencies:
     "@vscode/extension-telemetry" "^0.6.2"
 


### PR DESCRIPTION
Updates to use new 1DS key - the old AIF one will be deprecated.

This should be a transparent change, events will still show up the same as they were previously. 