### PR TITLE
Handle connection string parsing errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -475,6 +475,7 @@
     "mongodb": "4.5.0",
     "mongodb-connection-string-url": "2.5.2",
     "tar": "6.1.11",
+    "semver": "^7.3.2",
     "vscode-nls": "5.0.0",
     "yauzl": "2.10.0"
   },
@@ -487,6 +488,7 @@
     "@types/node-fetch": "2.6.2",
     "@types/tar": "6.1.2",
     "@types/tmp": "0.0.34",
+    "@types/semver": "^7.3.2",
     "@types/uuid": "8.3.1",
     "@types/yauzl": "2.9.2",
     "@typescript-eslint/eslint-plugin": "2.34.0",

--- a/src/Providers/connectionProvider.ts
+++ b/src/Providers/connectionProvider.ts
@@ -134,12 +134,15 @@ export class ConnectionProvider implements azdata.ConnectionProvider {
   // Called when something is pasted to Server field (Mongo account)
   buildConnectionInfo?(connectionString: string): Promise<azdata.ConnectionInfo> {
     console.log("ConnectionProvider.buildConnectionInfo");
-    const info = parseMongoConnectionString(connectionString);
-    if (!info) {
-      return Promise.reject("Could not parse connection string");
+    try {
+      const info = parseMongoConnectionString(connectionString);
+      if (info) {
+        return Promise.resolve(info);
+      }
+    } catch (e) {
+      console.error("Invalid MongoDB connection string", e);
     }
-
-    return Promise.resolve(info);
+    return undefined!;
   }
   registerOnConnectionComplete(handler: (connSummary: azdata.ConnectionInfoSummary) => any): void {
     console.log("ConnectionProvider.registerOnConnectionComplete");

--- a/src/Providers/connectionProvider.ts
+++ b/src/Providers/connectionProvider.ts
@@ -1,6 +1,7 @@
 import * as azdata from "azdata";
 import * as vscode from "vscode";
 import * as nls from "vscode-nls";
+import * as semver from "semver";
 import { v4 as uuid } from "uuid";
 import { AppContext } from "../appContext";
 import { parseMongoConnectionString } from "./connectionString";
@@ -141,6 +142,10 @@ export class ConnectionProvider implements azdata.ConnectionProvider {
       }
     } catch (e) {
       console.error("Invalid MongoDB connection string", e);
+      if (semver.gte(azdata.version, "1.43.0")) {
+        // older ADS won't handle reject properly
+        return Promise.reject(e);
+      }
     }
     return undefined!;
   }


### PR DESCRIPTION
When the ConnectionString parser fails it'll throw resulting in the caller waiting indefinitely for the result.

Now the exception will be logged and the caller will show an error message as expected.

https://github.com/Azure/azure-cosmosdb-ads-extension/issues/37 might be related.