### PR TITLE
Add .editorconfig defining our own indent style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Tab indentation
+[*]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Since ADS has a different indend style (tabs) VS Code will keep reformatting our code when our repo
is cloned inside their extensions folder. Providing our own .editorconfig fixes this.