### PR TITLE
Fix connecting to a Mongo vCore cluster

### DIFF
--- a/src/Providers/connectionString.ts
+++ b/src/Providers/connectionString.ts
@@ -70,11 +70,18 @@ export const buildMongoConnectionString = (options: {
 
   // CosmosDB account need these parameters (hostname ends with cosmos.azure.com)
   if (options.server.match(/\.cosmos\.azure\.com(:[0-9]*)*$/g)) {
-    url.searchParams.set("ssl", "true");
-    url.searchParams.set("replicaSet", "globaldb");
     url.searchParams.set("retrywrites", "false");
     url.searchParams.set("maxIdleTimeMS", url.searchParams.get("maxIdleTimeMS") || "120000");
-    url.searchParams.set("appName", `@${options.user}@`);
+
+    if (!options.isServer) {
+      // always set this for RU based configs (not vCore)
+      url.searchParams.set("ssl", "true");
+      url.searchParams.set("replicaSet", "globaldb");
+      url.searchParams.set("appName", `@${options.user}@`);
+    } else {
+      // only for vCore
+      url.searchParams.set("tls", "true");
+    }
   }
   return url.toString();
 };

--- a/src/Providers/connectionString.ts
+++ b/src/Providers/connectionString.ts
@@ -93,6 +93,9 @@ export const buildMongoConnectionString = (options: {
       if (!url.searchParams.get("ssl") && !url.searchParams.get("tls")) {
         url.searchParams.set("tls", "true");
       }
+      if (!url.searchParams.get("authMechanism")) {
+        url.searchParams.set("authMechanism", "SCRAM-SHA-256");
+      }
     }
   }
   return url.toString();

--- a/src/Providers/connectionString.ts
+++ b/src/Providers/connectionString.ts
@@ -70,17 +70,29 @@ export const buildMongoConnectionString = (options: {
 
   // CosmosDB account need these parameters (hostname ends with cosmos.azure.com)
   if (options.server.match(/\.cosmos\.azure\.com(:[0-9]*)*$/g)) {
-    url.searchParams.set("retrywrites", "false");
-    url.searchParams.set("maxIdleTimeMS", url.searchParams.get("maxIdleTimeMS") || "120000");
+    if (!url.searchParams.get("retrywrites")) {
+      url.searchParams.set("retrywrites", "false");
+    }
+    if (!url.searchParams.get("maxIdleTimeMS")) {
+      url.searchParams.set("maxIdleTimeMS", "120000");
+    }
 
     if (!options.isServer) {
       // always set this for RU based configs (not vCore)
-      url.searchParams.set("ssl", "true");
-      url.searchParams.set("replicaSet", "globaldb");
-      url.searchParams.set("appName", `@${options.user}@`);
+      if (!url.searchParams.get("ssl") && !url.searchParams.get("tls")) {
+        url.searchParams.set("ssl", "true");
+      }
+      if (!url.searchParams.get("replicaSet")) {
+        url.searchParams.set("replicaSet", "globaldb");
+      }
+      if (!url.searchParams.get("appName")) {
+        url.searchParams.set("appName", `@${options.user}@`);
+      }
     } else {
       // only for vCore
-      url.searchParams.set("tls", "true");
+      if (!url.searchParams.get("ssl") && !url.searchParams.get("tls")) {
+        url.searchParams.set("tls", "true");
+      }
     }
   }
   return url.toString();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -239,6 +239,26 @@ suite("Connection String Test Suite", () => {
     assert.match(cs!, /appName=%40username%40/);
   });
 
+  test("Build connection string cosmosdb vCore account", () => {
+    const options = {
+      authenticationType: "SqlLogin",
+      user: "username",
+      password: "password",
+      server: "server.cosmos.azure.com",
+      pathname: "",
+      search: "",
+      isServer: true,
+    };
+    const cs = buildMongoConnectionString(options);
+    assert.strictEqual(cs !== undefined, true);
+    assert.doesNotMatch(cs!, /ssl=true/);
+    assert.doesNotMatch(cs!, /replicaSet=globaldb/);
+    assert.doesNotMatch(cs!, /appName=%40username%40/);
+    assert.match(cs!, /retrywrites=false/);
+    assert.match(cs!, /tls=true/);
+    assert.match(cs!, /maxIdleTimeMS=120000/);
+  });
+
   test("Build connection string cosmosdb account: do not overwrite maxIdleTimeMS", () => {
     const options = {
       authenticationType: "SqlLogin",

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -257,6 +257,7 @@ suite("Connection String Test Suite", () => {
     assert.match(cs!, /retrywrites=false/);
     assert.match(cs!, /tls=true/);
     assert.match(cs!, /maxIdleTimeMS=120000/);
+    assert.match(cs!, /authMechanism=SCRAM-SHA-256/);
   });
 
   test("Build connection string cosmosdb account: do not overwrite maxIdleTimeMS", () => {


### PR DESCRIPTION
When connecting to a Cosmos DB cluster some different connection string parameters are required, such as tls instead of ssl.

When rebuilding the connection info we now distinguish between RU and vCore and set the required parameters accordingly. In addition we don't want to enforce them, if user provided a connection string with a different option for any of these parameters, we just let them.