### PR TITLE
Improve vCore auth handling and dashboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -434,7 +434,7 @@
     "esbuild:watch": "yarn run esbuild:base --sourcemap --watch"
   },
   "dependencies": {
-    "@azure/arm-cosmosdb": "15.0.0",
+    "@azure/arm-cosmosdb": "15.4.0",
     "@azure/arm-monitor": "7.0.0",
     "@azure/arm-resourcegraph": "4.2.1",
     "@azure/cosmos": "3.17.3",

--- a/package.json
+++ b/package.json
@@ -434,7 +434,7 @@
     "esbuild:watch": "yarn run esbuild:base --sourcemap --watch"
   },
   "dependencies": {
-    "@azure/arm-cosmosdb": "15.4.0",
+    "@azure/arm-cosmosdb": "15.4.0-beta.2",
     "@azure/arm-monitor": "7.0.0",
     "@azure/arm-resourcegraph": "4.2.1",
     "@azure/cosmos": "3.17.3",

--- a/src/Dashboards/AbstractCosmosDbHomeDashboard.ts
+++ b/src/Dashboards/AbstractCosmosDbHomeDashboard.ts
@@ -41,7 +41,7 @@ export abstract class AbstractCosmosDbHomeDashboard extends AbstractHomeDashboar
           connectionInfo.options["azureAccount"],
           connectionInfo.options["azureTenantId"],
           connectionInfo.options["azureResourceId"],
-          connectionInfo.options["server"]
+          this.armService.getAccountName(connectionInfo)
         )
         .then((databaseAccountInfo) => {
           const propertyItems: azdata.PropertiesContainerItem[] = [

--- a/src/Dashboards/CosmosDbMongoClusterHomeDashboard.ts
+++ b/src/Dashboards/CosmosDbMongoClusterHomeDashboard.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from "azdata";
+import * as vscode from "vscode";
+import * as nls from "vscode-nls";
+import { MongoService } from "../Services/MongoService";
+import { AbstractArmService } from "../Services/AbstractArmService";
+import TelemetryReporter from "@microsoft/ads-extension-telemetry";
+import { NativeMongoHomeDashboard } from "./NativeMongoHomeDashboard";
+import { AbstractCosmosDbHomeDashboard } from "./AbstractCosmosDbHomeDashboard";
+
+const localize = nls.loadMessageBundle();
+
+export class CosmosDbMongoClusterHomeDashboard extends NativeMongoHomeDashboard {
+  constructor(reporter: TelemetryReporter, mongoService: MongoService, private armService: AbstractArmService) {
+    super(reporter, mongoService);
+  }
+
+  protected createModelViewItems(view: azdata.ModelView, context: vscode.ExtensionContext): azdata.Component[] {
+    const viewItems: azdata.Component[] = [this.buildOverview(view)];
+    return viewItems.concat(super.createModelViewItems(view, context));
+  }
+
+  private buildOverview(view: azdata.ModelView): azdata.Component {
+    this.refreshProperties = () => {
+      const connectionInfo = view.connection;
+      this.armService
+        .retrieveClusterInfo(
+          connectionInfo.options["azureAccount"],
+          connectionInfo.options["azureTenantId"],
+          connectionInfo.options["azureResourceId"],
+          this.armService.getAccountName(connectionInfo)
+        )
+        .then((mongoClusterInfo) => {
+          const propertyItems: azdata.PropertiesContainerItem[] = [
+            {
+              displayName: localize("status", "Status"),
+              value: mongoClusterInfo.provisioningStatus + ", " + mongoClusterInfo.clusterStatus,
+            },
+            {
+              displayName: localize("mongoVersion", "Mongo DB Version"),
+              value: mongoClusterInfo.serverVersion,
+            },
+            {
+              displayName: localize("location", "Location"),
+              value: mongoClusterInfo.location,
+            },
+          ];
+
+          properties.propertyItems = propertyItems;
+          component.loading = false;
+        });
+    };
+    this.refreshProperties();
+
+    const propertyItems: azdata.PropertiesContainerItem[] = [];
+    const properties = view.modelBuilder.propertiesContainer().withProps({ propertyItems }).component();
+
+    const overview = view.modelBuilder
+      .divContainer()
+      .withItems([properties])
+      .withProps({
+        CSSStyles: {
+          padding: "10px",
+          "border-bottom": "1px solid rgba(128, 128, 128, 0.35)",
+        },
+      })
+      .component();
+
+    const component = view.modelBuilder
+      .loadingComponent()
+      .withItem(overview)
+      .withProps({
+        loading: true,
+      })
+      .component();
+
+    return component;
+  }
+
+  protected createGettingStartedDefaultButtons(
+    view: azdata.ModelView,
+    context: vscode.ExtensionContext
+  ): azdata.ButtonComponent[] {
+    let heroCardsContainer = super.createGettingStartedDefaultButtons(view, context);
+    heroCardsContainer.push(
+      AbstractCosmosDbHomeDashboard.createOpenInPortalButton(view, context, this.reporter, this.armService)
+    );
+    return heroCardsContainer;
+  }
+}

--- a/src/Dashboards/NativeMongoHomeDashboard.ts
+++ b/src/Dashboards/NativeMongoHomeDashboard.ts
@@ -169,9 +169,14 @@ export class NativeMongoHomeDashboard extends AbstractHomeDashboard {
 
   public buildModel(view: azdata.ModelView, context: vscode.ExtensionContext): azdata.FlexContainer {
     const viewItems: azdata.Component[] = [this.buildToolbar(view, context)];
-    viewItems.push(this.buildGettingStarted(view, context));
-
+    this.createModelViewItems(view, context).forEach((p) => {
+      viewItems.push(p);
+    });
     return view.modelBuilder.flexContainer().withItems(viewItems).withLayout({ flexFlow: "column" }).component();
+  }
+
+  protected createModelViewItems(view: azdata.ModelView, context: vscode.ExtensionContext): azdata.Component[] {
+    return [this.buildGettingStarted(view, context)];
   }
 
   private buildGettingStarted(view: azdata.ModelView, context: vscode.ExtensionContext): azdata.Component {

--- a/src/Dashboards/homeDashboard.ts
+++ b/src/Dashboards/homeDashboard.ts
@@ -25,7 +25,7 @@ export const registerMongoHomeDashboardTabs = (context: vscode.ExtensionContext,
 
   azdata.ui.registerModelViewProvider("mongo-account-home", async (view) => {
     await view.initializeModel(
-      isAzureConnection(view.connection)
+      isAzureConnection(view.connection) && !view.connection.options["isServer"]
         ? cosmosDbMongoHomeDashboard.buildModel(view, context)
         : nativeMongoDashboard.buildModel(view, context)
     );
@@ -33,7 +33,7 @@ export const registerMongoHomeDashboardTabs = (context: vscode.ExtensionContext,
 
   azdata.ui.registerModelViewProvider("mongo-databases.tab", async (view) => {
     await view.initializeModel(
-      isAzureConnection(view.connection)
+      isAzureConnection(view.connection) && !view.connection.options["isServer"]
         ? await cosmosDbMongoHomeDashboard.buildDatabasesArea(view, context)
         : await nativeMongoDashboard.buildDatabasesArea(view, context)
     );

--- a/src/Dashboards/homeDashboard.ts
+++ b/src/Dashboards/homeDashboard.ts
@@ -12,12 +12,18 @@ import { ArmServiceMongo } from "../Services/ArmServiceMongo";
 import { ArmServiceNoSql } from "../Services/ArmServiceNoSql";
 import { CosmosDbMongoHomeDashboard } from "./CosmosDbMongoHomeDashboard";
 import { CosmosDbNoSqlHomeDashboard } from "./CosmosDbNoSqlHomeDashboard";
+import { CosmosDbMongoClusterHomeDashboard } from "./CosmosDbMongoClusterHomeDashboard";
 
 const dashboards = [];
 
 export const registerMongoHomeDashboardTabs = (context: vscode.ExtensionContext, appContext: AppContext): void => {
   const cosmosDbMongoHomeDashboard = new CosmosDbMongoHomeDashboard(appContext.reporter, new ArmServiceMongo());
   const cosmosDbNoSqlHomeDashboard = new CosmosDbNoSqlHomeDashboard(appContext.reporter, new ArmServiceNoSql());
+  const cosmosDbMongoClusterHomeDashboard = new CosmosDbMongoClusterHomeDashboard(
+    appContext.reporter,
+    appContext.mongoService,
+    new ArmServiceMongo()
+  );
   const nativeMongoDashboard = new NativeMongoHomeDashboard(appContext.reporter, appContext.mongoService);
   dashboards.push(cosmosDbMongoHomeDashboard);
   dashboards.push(cosmosDbNoSqlHomeDashboard);
@@ -25,8 +31,10 @@ export const registerMongoHomeDashboardTabs = (context: vscode.ExtensionContext,
 
   azdata.ui.registerModelViewProvider("mongo-account-home", async (view) => {
     await view.initializeModel(
-      isAzureConnection(view.connection) && !view.connection.options["isServer"]
-        ? cosmosDbMongoHomeDashboard.buildModel(view, context)
+      isAzureConnection(view.connection)
+        ? view.connection.options["isServer"]
+          ? cosmosDbMongoClusterHomeDashboard.buildModel(view, context)
+          : cosmosDbMongoHomeDashboard.buildModel(view, context)
         : nativeMongoDashboard.buildModel(view, context)
     );
   });

--- a/src/Providers/connectionProvider.ts
+++ b/src/Providers/connectionProvider.ts
@@ -49,7 +49,7 @@ export class ConnectionProvider implements azdata.ConnectionProvider {
     try {
       connectionString = await this.backendService.retrieveConnectionStringFromConnectionOptions(
         connectionOptions,
-        false
+        true
       );
       this.connectionUriToConnectionStringMap.set(connectionUri, connectionString);
     } catch (e) {

--- a/src/Services/AbstractArmService.ts
+++ b/src/Services/AbstractArmService.ts
@@ -254,8 +254,17 @@ export abstract class AbstractArmService {
   };
 
   // TODO Find a better way to express this
-  public getAccountName = (connectionInfo: azdata.ConnectionInfo): string => connectionInfo.options["server"];
-  public getAccountNameFromOptions = (connectionOptions: IConnectionOptions): string => connectionOptions.server;
+  public getAccountName = (connectionInfo: azdata.ConnectionInfo): string =>
+    AbstractArmService.trimAzureHost(connectionInfo.options["server"]);
+  public getAccountNameFromOptions = (connectionOptions: IConnectionOptions): string =>
+    AbstractArmService.trimAzureHost(connectionOptions.server);
+
+  static trimAzureHost = (server: string): string => {
+    if (server.includes("cosmos.azure.com")) {
+      return server.replace(".mongocluster.cosmos.azure.com", "").replace(".mongo.cosmos.azure.com", "");
+    }
+    return server;
+  };
 
   protected retrieveResourceInfofromArm = async (
     cosmosDbAccountName: string,

--- a/src/Services/AbstractArmService.ts
+++ b/src/Services/AbstractArmService.ts
@@ -294,7 +294,7 @@ export abstract class AbstractArmService {
     AbstractArmService.trimAzureHost(connectionOptions.server);
 
   static trimAzureHost = (server: string): string => {
-    if (server.includes("cosmos.azure.com")) {
+    if (server.endsWith("cosmos.azure.com")) {
       return server.replace(".mongocluster.cosmos.azure.com", "").replace(".mongo.cosmos.azure.com", "");
     }
     return server;

--- a/src/Services/AbstractBackendService.ts
+++ b/src/Services/AbstractBackendService.ts
@@ -37,23 +37,25 @@ export abstract class AbstractBackendService {
         }
       case "SqlLogin":
       case "Integrated":
-        if (retrievePasswordFromAzData) {
+        const serverName = connectionOptions.server;
+        if (!connectionOptions.password && retrievePasswordFromAzData) {
           // Retrieve password
-          const serverName = connectionOptions.server;
           if (!serverName) {
             vscode.window.showErrorMessage(localize("missingServerName", "Missing serverName {0}", serverName));
             return undefined;
           }
 
           const connection = (await azdata.connection.getConnections()).filter((c) => c.serverName === serverName);
-          if (connection.length < 1) {
-            vscode.window.showErrorMessage(
-              localize("failRetrieveCredentials", "Unable to retrieve credentials for {0}", serverName)
-            );
-            return undefined;
+          if (connection.length > 0) {
+            const credentials = await azdata.connection.getCredentials(connection[0].connectionId);
+            connectionOptions.password = credentials["password"];
           }
-          const credentials = await azdata.connection.getCredentials(connection[0].connectionId);
-          connectionOptions.password = credentials["password"];
+        }
+        if (!connectionOptions.password) {
+          vscode.window.showErrorMessage(
+            localize("failRetrieveCredentials", "Unable to retrieve credentials for {0}", serverName)
+          );
+          return undefined;
         }
         return buildMongoConnectionString(connectionOptions);
       default:

--- a/src/Services/AbstractBackendService.ts
+++ b/src/Services/AbstractBackendService.ts
@@ -22,25 +22,6 @@ export abstract class AbstractBackendService {
   ): Promise<string | undefined> => {
     const authenticationType = connectionOptions.authenticationType;
 
-    if (retrievePasswordFromAzData && (authenticationType === "SqlLogin" || authenticationType === "Integrated")) {
-      // Retrieve password
-      const serverName = connectionOptions.server;
-      if (!serverName) {
-        vscode.window.showErrorMessage(localize("missingServerName", "Missing serverName {0}", serverName));
-        return undefined;
-      }
-
-      const connection = (await azdata.connection.getConnections()).filter((c) => c.serverName === serverName);
-      if (connection.length < 1) {
-        vscode.window.showErrorMessage(
-          localize("failRetrieveCredentials", "Unable to retrieve credentials for {0}", serverName)
-        );
-        return undefined;
-      }
-      const credentials = await azdata.connection.getCredentials(connection[0].connectionId);
-      connectionOptions.password = credentials["password"];
-    }
-
     switch (authenticationType) {
       case "AzureMFA":
         try {
@@ -56,6 +37,24 @@ export abstract class AbstractBackendService {
         }
       case "SqlLogin":
       case "Integrated":
+        if (retrievePasswordFromAzData) {
+          // Retrieve password
+          const serverName = connectionOptions.server;
+          if (!serverName) {
+            vscode.window.showErrorMessage(localize("missingServerName", "Missing serverName {0}", serverName));
+            return undefined;
+          }
+
+          const connection = (await azdata.connection.getConnections()).filter((c) => c.serverName === serverName);
+          if (connection.length < 1) {
+            vscode.window.showErrorMessage(
+              localize("failRetrieveCredentials", "Unable to retrieve credentials for {0}", serverName)
+            );
+            return undefined;
+          }
+          const credentials = await azdata.connection.getCredentials(connection[0].connectionId);
+          connectionOptions.password = credentials["password"];
+        }
         return buildMongoConnectionString(connectionOptions);
       default:
         // Should never happen

--- a/src/Services/MongoService.ts
+++ b/src/Services/MongoService.ts
@@ -7,7 +7,7 @@ import { IConnectionNodeInfo, IDatabaseDashboardInfo } from "../extension";
 import { createNodePath } from "../Providers/objectExplorerNodeProvider";
 import { CdbCollectionCreateInfo } from "../sampleData/DataSamplesUtil";
 import { EditorUserQuery, EditorQueryResult, QueryOffsetPagingInfo } from "../QueryClient/messageContract";
-import { SampleData, askUserForConnectionProfile, isAzureAuthType } from "./ServiceUtil";
+import { SampleData, askUserForConnectionProfile, isAzureConnection } from "./ServiceUtil";
 import { hideStatusBarItem, showStatusBarItem } from "../appContext";
 import { AbstractBackendService } from "./AbstractBackendService";
 import { ArmServiceMongo } from "./ArmServiceMongo";
@@ -110,7 +110,7 @@ export class MongoService extends AbstractBackendService {
     connectionOptions: IConnectionOptions,
     databaseName?: string
   ): Promise<{ databaseName: string }> {
-    return isAzureAuthType(connectionOptions.authenticationType)
+    return isAzureConnection(connectionOptions) && !connectionOptions.isServer
       ? this.createMongoDatabaseWithArm(connectionOptions, databaseName)
       : // In MongoDB, a database cannot be empty.
         this.createMongoDbCollectionWithMongoDbClient(connectionOptions, databaseName, undefined);
@@ -130,7 +130,7 @@ export class MongoService extends AbstractBackendService {
     collectionName?: string,
     cdbCreateInfo?: CdbCollectionCreateInfo
   ): Promise<{ databaseName: string; collectionName: string | undefined }> {
-    return isAzureAuthType(connectionOptions.authenticationType)
+    return isAzureConnection(connectionOptions) && !connectionOptions.isServer
       ? this.createMongoDatabaseAndCollectionWithArm(connectionOptions, databaseName, collectionName)
       : this.createMongoDbCollectionWithMongoDbClient(connectionOptions, databaseName, collectionName);
   }

--- a/src/Services/ServiceUtil.ts
+++ b/src/Services/ServiceUtil.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as nls from "vscode-nls";
 import * as azdata from "azdata";
 import { MongoProviderId } from "../Providers/connectionProvider";
+import { convertToConnectionOptions, IConnectionOptions } from "../models";
 
 const localize = nls.loadMessageBundle();
 
@@ -35,7 +36,23 @@ export interface SampleData {
   };
 }
 
-export const isAzureConnection = (connectionInfo: azdata.ConnectionInfo): boolean =>
-  isAzureAuthType(connectionInfo.options["authenticationType"]);
+export const isAzureConnection = (connectionInfo: azdata.ConnectionInfo | IConnectionOptions): boolean => {
+  const info = "options" in connectionInfo ? convertToConnectionOptions(connectionInfo) : connectionInfo;
+  if (isAzureAuthType(info.authenticationType)) {
+    return true;
+  }
+  if (info.azureAccount !== undefined && info.azureResourceId !== undefined && info.azureTenantId !== undefined) {
+    return true;
+  }
+  /*
+    const server: string = connectionInfo.options["server"];//
+    let startDomain: number;
+    const clusterDomain = ".mongocluster.cosmos.azure.com";
+    if ((startDomain = server.indexOf(clusterDomain)) > 0 && server.length === startDomain + clusterDomain.length) {
+      return true;
+    }
+    */
+  return false;
+};
 
 export const isAzureAuthType = (authenticationType: string | undefined): boolean => authenticationType === "AzureMFA";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ import TelemetryReporter from "@microsoft/ads-extension-telemetry";
 import { getErrorMessage, getPackageInfo } from "./util";
 import { CdbCollectionCreateInfo } from "./sampleData/DataSamplesUtil";
 import { EditorUserQuery } from "./QueryClient/messageContract";
-import { askUserForConnectionProfile, isAzureAuthType } from "./Services/ServiceUtil";
+import { askUserForConnectionProfile, isAzureConnection } from "./Services/ServiceUtil";
 import { CosmosDbMongoDatabaseDashboard } from "./Dashboards/CosmosDbMongoDatabaseDashboard";
 import { NativeMongoDatabaseDashboard } from "./Dashboards/NativeMongoDatabaseDashboard";
 import { ArmServiceMongo } from "./Services/ArmServiceMongo";
@@ -396,9 +396,10 @@ export function activate(context: vscode.ExtensionContext) {
           return;
         }
 
-        const databaseDashboard = isAzureAuthType(databaseDashboardInfo.authenticationType)
-          ? new CosmosDbMongoDatabaseDashboard(MongoProviderId, new ArmServiceMongo())
-          : new NativeMongoDatabaseDashboard(MongoProviderId);
+        const databaseDashboard =
+          isAzureConnection(databaseDashboardInfo) && !databaseDashboardInfo.isServer
+            ? new CosmosDbMongoDatabaseDashboard(MongoProviderId, new ArmServiceMongo())
+            : new NativeMongoDatabaseDashboard(MongoProviderId);
         databaseDashboard.openDatabaseDashboard(databaseDashboardInfo, appContext, context);
       }
     )

--- a/src/models.ts
+++ b/src/models.ts
@@ -16,6 +16,13 @@ export interface ICosmosDbDatabaseAccountInfo {
   documentEndpoint: string | undefined;
 }
 
+export interface ICosmosDbClusterInfo {
+  provisioningStatus: string;
+  location: string;
+  serverVersion: string;
+  clusterStatus: string;
+}
+
 export interface ICosmosDbDatabaseInfo {
   name: string;
   nbCollections: number | undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,17 +9,17 @@
   dependencies:
     tslib "^2.2.0"
 
-"@azure/arm-cosmosdb@15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@azure/arm-cosmosdb/-/arm-cosmosdb-15.0.0.tgz#5195b1b301d8c489df35805cc24934fd2ea77f79"
-  integrity sha512-F0lrY+11XRBwMZgXUkGMh8EaSmeHCWjRgblRp+PKlce3UUmC4lgbrZYrJdhE2rxDkOS4sz+zL1lnN2qMuejSNg==
+"@azure/arm-cosmosdb@15.4.0-beta.2":
+  version "15.4.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@azure/arm-cosmosdb/-/arm-cosmosdb-15.4.0-beta.2.tgz#de14cd514642ed9d3f3fd79b79466756a657cd79"
+  integrity sha512-BphEKsl9Q07Eom2+qDx84p/wJChjz2geEctuUDThPBTG4NQRELB6973K9zVLm4MT9lO9Vl9n3kNAGS+zdGu2oQ==
   dependencies:
     "@azure/abort-controller" "^1.0.0"
     "@azure/core-auth" "^1.3.0"
-    "@azure/core-client" "^1.0.0"
-    "@azure/core-lro" "^2.2.0"
+    "@azure/core-client" "^1.7.0"
+    "@azure/core-lro" "^2.5.0"
     "@azure/core-paging" "^1.2.0"
-    "@azure/core-rest-pipeline" "^1.1.0"
+    "@azure/core-rest-pipeline" "^1.8.0"
     tslib "^2.2.0"
 
 "@azure/arm-monitor@7.0.0":
@@ -53,7 +53,7 @@
     "@azure/abort-controller" "^1.0.0"
     tslib "^2.2.0"
 
-"@azure/core-client@^1.0.0":
+"@azure/core-client@^1.0.0", "@azure/core-client@^1.7.0":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@azure/core-client/-/core-client-1.7.2.tgz#e1e0670c9a5086dd62fd0080d2fd8b426babad9e"
   integrity sha512-ye5554gnVnXdfZ64hptUtETgacXoRWxYv1JF5MctoAzTSH5dXhDPZd9gOjDPyWMcLIk58pnP5+p5vGX6PYn1ag==
@@ -72,6 +72,16 @@
   integrity sha512-JHQy/bA3NOz2WuzOi5zEk6n/TJdAropupxUT521JIJvW7EXV2YN2SFYZrf/2RHeD28QAClGdynYadZsbmP+nyQ==
   dependencies:
     "@azure/abort-controller" "^1.0.0"
+    "@azure/logger" "^1.0.0"
+    tslib "^2.2.0"
+
+"@azure/core-lro@^2.5.0":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@azure/core-lro/-/core-lro-2.5.3.tgz#6bb74e76dd84071d319abf7025e8abffef091f91"
+  integrity sha512-ubkOf2YCnVtq7KqEJQqAI8dDD5rH1M6OP5kW0KO/JQyTaxLA0N0pjFWvvaysCj9eHMNBcuuoZXhhl0ypjod2DA==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-util" "^1.2.0"
     "@azure/logger" "^1.0.0"
     tslib "^2.2.0"
 
@@ -98,6 +108,21 @@
     tslib "^2.2.0"
     uuid "^8.3.0"
 
+"@azure/core-rest-pipeline@^1.8.0":
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.3.tgz#7603afd71ff3c290351dbeeab2c814832e47b8ef"
+  integrity sha512-AMQb0ttiGJ0MIV/r+4TVra6U4+90mPeOveehFnrqKlo7dknPJYdJ61wOzYJXJjDxF8LcCtSogfRelkq+fCGFTw==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-tracing" "^1.0.1"
+    "@azure/core-util" "^1.3.0"
+    "@azure/logger" "^1.0.0"
+    form-data "^4.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.0"
+    tslib "^2.2.0"
+
 "@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.0.1.tgz#352a38cbea438c4a83c86b314f48017d70ba9503"
@@ -109,6 +134,14 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.2.0.tgz#3499deba1fc36dda6f1912b791809b6f15d4a392"
   integrity sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    tslib "^2.2.0"
+
+"@azure/core-util@^1.2.0", "@azure/core-util@^1.3.0":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.3.2.tgz#3f8cfda1e87fac0ce84f8c1a42fcd6d2a986632d"
+  integrity sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==
   dependencies:
     "@azure/abort-controller" "^1.0.0"
     tslib "^2.2.0"


### PR DESCRIPTION
## vCore Auth

When building a connection string with simple auth we now always require a password. The is necessary because ARM won't provide a password for vCore clusters unlike it does for mongo accounts, since the password is set by the user and encrypted.

This can happen especially when connecting to a vCore cluster from the Azure browser, where the password will be `null`.

In addition if ADS has once successfully connected to the resource it will preserve the password through IConnectionOptions so there is no need to re-query it from the keychain.

_IMPORTANT: this will break the "No Auth" option._

## vCore Dashboards

This PR adds vCore support to dashboards and improves detection whether a service is vCore, Cosmos DB Mongo Account or native Mongo. For vCore native dashboards are reused (ARM has not resource management support for vCore yet), only the home dashboard is based on native extending it with Azure specific status area and an "Open in Portal" button.

## Dependencies
**arm-cosmosdb: 15.4.0**, not officially released yet and available here: https://github.com/Azure/sdk-release-request/issues/3978#issuecomment-1504682014
Install it manually by unzipping [azure-arm-cosmosdb-15.4.0-beta.2.zip](https://github.com/Azure/sdk-release-request/files/11084729/azure-arm-cosmosdb-15.4.0-beta.2.zip) and installing it using `npm install --save [path-to-package]/azure-arm-cosmosdb-15.4.0-beta.2/package`

**azuredatastudio patch:** https://github.com/microsoft/azuredatastudio/pull/22512, required for vCore support in the `azurecore` extension.

## Next Steps

- [x] Update **arm-cosmosdb** to 15.4.0
- [ ] Merge azuredatastudio patch: https://github.com/microsoft/azuredatastudio/pull/22512

## Further Improvements

* Connection string from ARM: currently we build the connection string for vCore manually in code because arm-cosmosdb didn't have support for that. With 15.4.0 the connection string can be retrieved from ARM like we already do for Mongo Accounts, but it will need additional treatment to replace the `<username>` and `<password>` placeholders with the actual credentials.
* More cluster details: only displaying the status and region is currently implemented. ARM provides more useful information such as disk size, which could be added to the home dashboard.