### PR TITLE
Fix Mongo Shell executable flag on *NIX

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -572,6 +572,13 @@ export function activate(context: vscode.ExtensionContext) {
         try {
           showStatusBarItem(localize("downloadingMongoShell", "Downloading mongo shell..."));
           executablePath = await downloadMongoShell(context.extensionPath);
+
+          switch (process.platform) {
+            case "darwin":
+            case "linux":
+              await fs.promises.chmod(executablePath, "755");
+              break;
+          }
           hideStatusBarItem();
         } catch (e) {
           if (!executablePath) {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cosmosdb-ads-extension/issues/72