### PR TITLE
Add License section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+## License
+
+This extension is licensed under the [MIT License](https://github.com/Azure/azure-cosmosdb-ads-extension/blob/main/LICENSE).


### PR DESCRIPTION
This is a requirement by CELA to have a license section in the README with a link to the license for each ADS extension.